### PR TITLE
Add initial PumpFun scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pump_results.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # ExeOheDus
-ExeOheDus: Memecoin 30k 2x Pump Scraper
+
+PumpFun memecoin scraper detecting tokens that pumped above 30k twice.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the scraper:
+
+```bash
+python -m src.scraper
+```
+
+The results will be saved to `pump_results.json`.
+
+## Tests
+
+Run unit tests with pytest:
+
+```bash
+pytest
+```

--- a/diagram.sh
+++ b/diagram.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+cat <<'DIAGRAM'
+            +---------------+
+            | PumpFun Site  |
+            +---------------+
+                    |
+                [Scraper]
+                    |
+             +-------------+
+             | Data Store  |
+             +-------------+
+              /           \
+Phase 2 --> [Telegram Bot]  \
+              \             \
+          Phase 3 --> [Web Application]
+DIAGRAM

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+beautifulsoup4
+pytest

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""ExeOheDus scraping package"""

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,8 @@
+PUMPFUN_URL = "https://pump.fun"
+THRESHOLD = 30000
+
+# If using environment variables or .env file for API keys, proxies, etc.
+import os
+
+PROXY = os.getenv("PUMPFUN_PROXY")
+

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,0 +1,36 @@
+import requests
+from bs4 import BeautifulSoup
+from .config import PUMPFUN_URL, THRESHOLD, PROXY
+
+
+def fetch_page(url: str) -> str:
+    response = requests.get(url, proxies={"http": PROXY, "https": PROXY} if PROXY else None)
+    response.raise_for_status()
+    return response.text
+
+
+def parse_pumps(html: str):
+    soup = BeautifulSoup(html, "html.parser")
+    # Placeholder: adapt to PumpFun's actual HTML structure
+    tokens = []
+    for token in soup.select("div.token"):  # Example selector
+        name = token.select_one(".name").get_text(strip=True)
+        pump_count = int(token.select_one(".pump-count").get_text())
+        if pump_count >= 2:
+            volume = int(token.select_one(".volume").get_text().replace(',', ''))
+            if volume >= THRESHOLD:
+                tokens.append({"name": name, "volume": volume, "pumps": pump_count})
+    return tokens
+
+
+def scrape_pumpfun():
+    html = fetch_page(PUMPFUN_URL)
+    tokens = parse_pumps(html)
+    return tokens
+
+
+if __name__ == "__main__":
+    from .storage import save_results
+    tokens = scrape_pumpfun()
+    save_results(tokens)
+    print(f"Saved {len(tokens)} tokens")

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,0 +1,9 @@
+import json
+from pathlib import Path
+
+DEFAULT_OUTPUT = Path("pump_results.json")
+
+
+def save_results(tokens, path: Path = DEFAULT_OUTPUT):
+    path.write_text(json.dumps(tokens, indent=2))
+

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src import scraper
+
+
+def test_scrape_pumpfun(monkeypatch):
+    html = '''
+    <div class="token"><span class="name">FOO</span><span class="pump-count">2</span><span class="volume">32000</span></div>
+    <div class="token"><span class="name">BAR</span><span class="pump-count">1</span><span class="volume">50000</span></div>
+    '''
+    monkeypatch.setattr(scraper, 'fetch_page', lambda url: html)
+    tokens = scraper.scrape_pumpfun()
+    assert tokens == [{'name': 'FOO', 'volume': 32000, 'pumps': 2}]


### PR DESCRIPTION
## Summary
- set up src package with config and scraper modules
- add storage helper and basic CLI for scraping
- include bash diagram
- document usage and tests in README
- add pytest-based unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851011e35588321b4c9846d16738003